### PR TITLE
removed webhooks from decorator, added as a hooks library

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,4 +1,4 @@
-from potassium import Potassium, Request, Response
+from potassium import Potassium, Request, Response, send_webhook
 from transformers import pipeline
 import torch
 import time
@@ -30,21 +30,18 @@ def handler(context: dict, request: Request) -> Response:
         status=200
     )
 
-@app.async_handler("/async", result_webhook="http://localhost:8001")
+@app.async_handler("/async")
 def handler(context: dict, request: Request) -> Response:
 
-    time.sleep(10)
+    time.sleep(2)
 
     prompt = request.json.get("prompt")
     model = context.get("model")
     outputs = model(prompt)
-    print("async done")
 
-    return Response(
-        json = {"outputs": outputs}, 
-        status=200
-    )
+    send_webhook(url="http://localhost:8001", json={"outputs": outputs})
 
+    return
 
 if __name__ == "__main__":
     app.serve()

--- a/potassium/__init__.py
+++ b/potassium/__init__.py
@@ -1,1 +1,2 @@
 from .potassium import *
+from .hooks import *

--- a/potassium/hooks.py
+++ b/potassium/hooks.py
@@ -1,0 +1,8 @@
+import requests
+import logging
+
+def send_webhook(url: str, json: dict):
+    try:
+        res = requests.post(url, json=json)
+    except requests.exceptions.ConnectionError:
+        print(f"Webhook to {url} failed with connection error")

--- a/potassium/hooks.py
+++ b/potassium/hooks.py
@@ -1,5 +1,4 @@
 import requests
-import logging
 
 def send_webhook(url: str, json: dict):
     try:

--- a/potassium/potassium.py
+++ b/potassium/potassium.py
@@ -6,17 +6,10 @@ from threading import Thread
 import functools
 from termcolor import colored
 
-def forward_to_webhook(url: str, json_out: dict):
-    try:
-        res = requests.post(url, json=json_out)
-    except Exception as e:
-        pass
-
 class Endpoint():
     def __init__(self, type, func, result_webhook = None):
         self.type = type
         self.func = func
-        self.result_webhook = result_webhook
 
 class Request():
     def __init__(self, json:dict, ws = None):
@@ -29,11 +22,10 @@ class Response():
         self.status = status
 
 class Potassium():
-    def __init__(self, name, mode = "serve"):
+    def __init__(self, name):
         def default_func():
             return
         self.name = name
-        self.mode = mode
         self.init_func = default_func
         self.endpoints = {} # dictionary to store unlimited Endpoints, by unique route
         self.context = {}
@@ -57,13 +49,13 @@ class Potassium():
         return actual_decorator
     
     # async_handler is a non-blocking http POST handler
-    def async_handler(self, route: str = "/", result_webhook:str = None):
+    def async_handler(self, route: str = "/"):
         def actual_decorator(func):
             @functools.wraps(func)
             def wrapper(request):
                 # send in app's stateful context, and the request
                 return func(self.context, request)
-            self.endpoints[route] = Endpoint(type="async_handler", func=wrapper, result_webhook=result_webhook)
+            self.endpoints[route] = Endpoint(type="async_handler", func=wrapper)
             return wrapper
         return actual_decorator
     
@@ -101,12 +93,10 @@ class Potassium():
                     json = request.get_json()
                 )
                 # run as threaded task
-                def task(func, req, webhook):
+                def task(func, req):
                     response = func(req)
-                    # Post results onward if webhook configured
-                    if webhook != None:
-                        forward_to_webhook(webhook, response.json)
-                thread = Thread(target=task, args=(endpoint.func, req, endpoint.result_webhook))
+                    # we currently do nothing with the response
+                thread = Thread(target=task, args=(endpoint.func, req))
                 thread.start()
 
                 # send task start success message
@@ -115,11 +105,11 @@ class Potassium():
         return flask_app
 
     # serve runs the http server
-    def serve(self):
+    def serve(self, port = 8000):
         print(colored("------\nStarting Potassium Server 🍌", 'yellow'))   
         print(colored("Running init()", 'yellow'))
         self.init_func()
         flask_app = self._create_flask_app()
-        server = make_server('localhost', 8000, flask_app)
+        server = make_server('localhost', port, flask_app)
         print(colored("Serving at http://localhost:8000\n------", 'green'))
         server.serve_forever()

--- a/potassium/potassium.py
+++ b/potassium/potassium.py
@@ -7,7 +7,7 @@ import functools
 from termcolor import colored
 
 class Endpoint():
-    def __init__(self, type, func, result_webhook = None):
+    def __init__(self, type, func):
         self.type = type
         self.func = func
 


### PR DESCRIPTION
# What is this?
removed webhooks from decorator, added as a hooks library

# Why?
to be more explicit, allow users to fire webhooks whenever they want in the handler

# How did you test to ensure no regressions?
I ran it and it worked

# If this is a new feature what is one way you can make this break?
