### PR TITLE
Feature/localstore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Development
+workspace/
+my-app/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/potassium/__init__.py
+++ b/potassium/__init__.py
@@ -1,3 +1,3 @@
 from .potassium import *
 from .hooks import *
-from .store import Store
+from .store import Store, RedisConfig

--- a/potassium/__init__.py
+++ b/potassium/__init__.py
@@ -1,2 +1,3 @@
 from .potassium import *
 from .hooks import *
+from .store import Store

--- a/potassium/potassium.py
+++ b/potassium/potassium.py
@@ -1,6 +1,5 @@
 import requests
-from flask import Flask
-from flask import request, abort
+from flask import Flask, request, make_response, abort
 from werkzeug.serving import make_server
 from threading import Thread
 import functools
@@ -63,6 +62,7 @@ class Potassium():
                 except Exception as e:
                     self._working = False
                     raise e
+
             self.endpoints[route] = Endpoint(type="background", func=wrapper)
             return wrapper
         return actual_decorator
@@ -94,7 +94,9 @@ class Potassium():
                 req = Request(
                     json = request.get_json()
                 )
-                return endpoint.func(req).json
+                res = make_response(endpoint.func(req).json)
+                res.headers['Endpoint-Type'] = endpoint.type
+                return res
             
             if endpoint.type == "background":
                 req = Request(
@@ -108,7 +110,9 @@ class Potassium():
                 thread.start()
 
                 # send task start success message
-                return {"started": True}
+                res = make_response({"started": True})
+                res.headers['Endpoint-Type'] = endpoint.type
+                return res
             
         return flask_app
 

--- a/potassium/potassium.py
+++ b/potassium/potassium.py
@@ -67,16 +67,6 @@ class Potassium():
             return wrapper
         return actual_decorator
     
-    # optional util
-    # set_context sets the app's context. This overwrites the prior context dictionary
-    def set_context(self, val:dict):
-        self.context = val
-
-    # optional util
-    # get_context gets the app's context
-    def get_context(self):
-        return self.context
-    
     def _create_flask_app(self):
         flask_app = Flask(__name__)
 

--- a/potassium/potassium.py
+++ b/potassium/potassium.py
@@ -4,7 +4,7 @@ from werkzeug.serving import make_server
 from threading import Thread, Lock
 import functools
 from termcolor import colored
-from queue import Queue
+from queue import Queue, Full
 
 class Endpoint():
     def __init__(self, type, func, gpu):
@@ -83,7 +83,10 @@ class Potassium():
                     return res
                 with self._lock:
                     response = endpoint.func(req).json
-                self.event_chan.put(item = True, block=False)
+                try:
+                    self.event_chan.put(item = True, block=False)
+                except Full:
+                    pass
 
             else:
                 response = endpoint.func(req).json
@@ -110,7 +113,10 @@ class Potassium():
                 if endpoint.gpu:
                     with lock:
                         endpoint.func(req)
-                    self.event_chan.put(item = True, block=False)
+                    try:
+                        self.event_chan.put(item = True, block=False)
+                    except Full:
+                        pass
                 else:
                     endpoint.func(req)
                 # we currently do nothing with the response

--- a/potassium/potassium.py
+++ b/potassium/potassium.py
@@ -43,8 +43,10 @@ class Potassium():
         def actual_decorator(func):
             @functools.wraps(func)
             def wrapper(request):
-                # send in app's stateful context, and the request
-                return func(self.context, request)
+                # send in app's stateful context if GPU, and the request
+                if gpu:
+                    return func(self.context, request)
+                return func(None, request)
             self.endpoints[route] = Endpoint(type="handler", func=wrapper, gpu=gpu)
             return wrapper
         return actual_decorator
@@ -54,8 +56,10 @@ class Potassium():
         def actual_decorator(func):
             @functools.wraps(func)
             def wrapper(request):
-                # send in app's stateful context, and the request
-                return func(self.context, request)
+                # send in app's stateful context if GPU, and the request
+                if gpu:
+                    return func(self.context, request)
+                return func(None, request)
             self.endpoints[route] = Endpoint(type="background", func=wrapper, gpu=gpu)
             return wrapper
         return actual_decorator

--- a/potassium/potassium.py
+++ b/potassium/potassium.py
@@ -81,7 +81,7 @@ class Potassium():
                 response = endpoint.func(req).json
 
             res = make_response(response)
-            res.headers['Endpoint-Type'] = endpoint.type
+            res.headers['X-Endpoint-Type'] = endpoint.type
             return res
         
         if endpoint.type == "background":
@@ -106,7 +106,7 @@ class Potassium():
 
             # send task start success message
             res = make_response({"started": True})
-            res.headers['Endpoint-Type'] = endpoint.type
+            res.headers['X-Endpoint-Type'] = endpoint.type
             return res
         
     def is_busy(self):

--- a/potassium/potassium.py
+++ b/potassium/potassium.py
@@ -73,6 +73,7 @@ class Potassium():
                 if self.is_busy():
                     res = make_response()
                     res.status_code = 423
+                    res.headers['X-Endpoint-Type'] = endpoint.type
                     return res
                 with self._lock:
                     response = endpoint.func(req).json
@@ -95,6 +96,7 @@ class Potassium():
                     if self.is_busy():
                         res = make_response()
                         res.status_code = 423
+                        res.headers['X-Endpoint-Type'] = endpoint.type
                         return res
                     with self._lock:
                         endpoint.func(req)

--- a/potassium/requirements.txt
+++ b/potassium/requirements.txt
@@ -1,3 +1,4 @@
 Flask
 requests
 termcolor
+redis

--- a/potassium/store.py
+++ b/potassium/store.py
@@ -1,0 +1,55 @@
+import time, os
+import shelve
+from threading import Thread, Lock
+import atexit
+
+
+class Entry():
+    def __init__(self, value, expiration):
+        self.value = value
+        self.expiration = expiration
+
+class Store():
+    def __init__(self, backend="local"):
+        self.backend = backend
+        if self.backend == "local": 
+            self._local_store = shelve.open(".localstore")
+            self._lock = Lock()
+            
+            # run TTL gc as thread
+            thread = Thread(target=self._gc)
+            thread.daemon = True
+            thread.start()
+
+            # delete store at exit, to avoid side effects
+            def exit_handler():
+                os.remove(".localstore")
+            atexit.register(exit_handler)
+
+    def _gc(self):
+        if self.backend == "local":
+            while True:
+                time.sleep(1)
+                with self._lock:
+                    try:
+                        for k, v in self._local_store.items():
+                            if v.expiration < time.time():
+                                del self._local_store[k]
+                    except:
+                        pass
+
+    def get(self, key: str):
+        if self.backend == "local":
+            with self._lock:
+                entry = self._local_store.get(key)
+            if entry == None:
+                return None
+            return entry.value
+    
+    def set(self, key, value, ttl=600):
+        if self.backend == "local":
+            with self._lock:
+                self._local_store[key] = Entry(
+                    value=value,
+                    expiration=time.time()+ttl
+                )

--- a/potassium/store.py
+++ b/potassium/store.py
@@ -1,17 +1,41 @@
 import time, os
+from typing import Union
 import shelve
 from threading import Thread, Lock
 import atexit
+import redis
+import pickle
+import json
 
 
 class Entry():
     def __init__(self, value, expiration):
         self.value = value
         self.expiration = expiration
-
+class RedisConfig():
+    def __init__(self, host:str, port:str, username:str = None, password:str = None, db:int = 0, encoding:str = "json"):
+        "encoding can be 'json' or 'pickle'. JSON is default.\nPickle has better support for arbitrary python types, but using pickle with a remote redis introduces a large security risk, see https://stackoverflow.com/questions/2259270/pickle-or-json/2259351#2259351"
+        # validate args
+        encodings = ["json", "pickle"]
+        if encoding not in encodings:
+            raise ValueError("redis config encoding must be one of the following:", encodings)
+        
+        self.host = host
+        self.port = port
+        self.username = username
+        self.password = password
+        self.db = db
+        self.encoding = encoding
 class Store():
-    def __init__(self, backend="local"):
+    def __init__(self, backend: str ="local", config: Union[None, RedisConfig] = None):
+        # validate args
+        backends = ["local", "redis"]
+        if backend not in backends:
+            raise ValueError("backend must be one of the following:", backends)
+        
         self.backend = backend
+        self.config = config
+         
         if self.backend == "local": 
             self._local_store = shelve.open(".localstore")
             self._lock = Lock()
@@ -25,6 +49,17 @@ class Store():
             def exit_handler():
                 os.remove(".localstore")
             atexit.register(exit_handler)
+
+        if self.backend == "redis":
+            if not isinstance(config, RedisConfig):
+                raise ValueError("redis backends require users to bring their own redis, and configure the potassium store to use it with the config argument. For example, to use a local redis, create store with:\n\nfrom potassium.store import Store, RedisConfig\nstore = Store(backend = 'redis', config = RedisConfig(host = 'localhost', port = 6379))")
+            self._redis_store = redis.Redis(
+                host=config.host, 
+                port=config.port,
+                username=config.username,
+                password=config.password,
+                db=config.db,
+            )
 
     def _gc(self):
         if self.backend == "local":
@@ -45,6 +80,15 @@ class Store():
             if entry == None:
                 return None
             return entry.value
+        
+        if self.backend == "redis":
+            encoded = self._redis_store.get(key)
+            if encoded == None:
+                return None
+            if self.config.encoding == "json":
+                return json.loads(encoded)
+            if self.config.encoding == "pickle":
+                return pickle.loads(encoded)
     
     def set(self, key, value, ttl=600):
         if self.backend == "local":
@@ -53,3 +97,10 @@ class Store():
                     value=value,
                     expiration=time.time()+ttl
                 )
+
+        if self.backend == "redis":
+            if self.config.encoding == "json":
+                encoded = json.dumps(value)
+            if self.config.encoding == "pickle":
+                encoded = pickle.dumps(value)
+            self._redis_store.set(key, encoded, ex=ttl)

--- a/potassium/store_test.py
+++ b/potassium/store_test.py
@@ -1,0 +1,70 @@
+from store import Store, RedisConfig
+
+# Redis store can save json serializeable objects
+store = Store(
+    backend="redis", 
+    config = RedisConfig(
+        host = "localhost", 
+        port = 6379
+    )
+)
+
+objs = [
+    "1",
+    True,
+    ["some", "list"],
+    {"some": {"nested": "dict"}}
+]
+
+print("Testing json redis")
+for obj in objs:
+    store.set("key", obj)
+    out = store.get("key")
+    if out != obj:
+        print("failed case", obj)
+
+# ----
+
+# pickle redis and localstore can save complex objects
+
+class Complex():
+    def __init__(self, a) -> None:
+        self.a = a
+    def __eq__ (self, other): # necessary for the equal assert later
+        return self.a == other.a
+
+objs = [
+    "1",
+    True,
+    ["some", "list"],
+    {"some": {"nested": "dict"}},
+    Complex(a = 1)
+]
+
+store = Store(
+    backend="redis", 
+    config = RedisConfig(
+        host = "localhost", 
+        port = 6379,
+        encoding = "pickle"
+    )
+)
+
+print("Testing pickle redis")
+for obj in objs:
+    store.set("key", obj)
+    out = store.get("key")
+    if obj != obj:
+        print("failed case", obj)
+
+# local store can save complex objects
+store = Store()
+
+print("Testing local store")
+for obj in objs:
+    store.set("key", obj)
+    out = store.get("key")
+    if out != obj:
+        print("failed case", obj)
+
+


### PR DESCRIPTION
# Foreword, Banana direction
More details yet to be shared, but Banana is reworking its inference API within a month, moving away from the async worker queue pattern (start / check with taskID). We believe that design has added unnecessary latency, reduced traceability for both ourselves and our users, and been a black box system which users have needed to fight with.

The Banana API will soon be "here's a URL to call your deployment directly at". You'll be able to handle multiple url routes in your server. We'll still be load-balancing calls across replicas and autoscaling from 0->n. But there will be no transformation of your call between your POST request and it arriving at your Potassium server. 

We're moving any call-management logic into open-source, via Potassium.

# What is this?

We add a local key-value Store object, for use between calls. All objects have TTLs, to prevent exploding memory/storage.

We also rename async_handler() to background(), which we feel better communicates that it's a background task, rather than an awaitable async function that returns results once awaited.

[You can see a demo of it here.](loom.com/share/c876b8b97d934b8daf324b73c355ea87)

# Why?

1. We hope this to be our first step toward building on Banana to feel like composing a proper backend rather than a just handler.

2. Users must be able to continue to use start/check async patterns as they do in Banana's current API. Background tasks, coupled with a local Store, allows users to build the start/check pattern themselves (we'll provide examples, of course). 

# How did you test to ensure no regressions?
Tested in demo video linked above, feel free to watch. This feature only becomes relevant to users in a month once Banana V2 API is live in a month.

# If this is a new feature what is one way you can make this break?
- There's currently no limit to TTL, we'll certainly be adding one before merging here. A user abusing this would have a memory leak in their server, and if on the shared cluster, cause issues to any neighbors running on the same machine.
- There's currently no limit to store size, we may add one. A user abusing this can crash Banana's disks.
- Users trying to put GPU-bound objects into the store will get an error at runtime as the store depends on pickle. As most users don't test before pushing to Banana (🙄), and if they do it's often on CPU machines, this error won't appear until models are deployed. (Test your code plz I'm begging you)