### PR TITLE
added redis store

### DIFF
--- a/potassium/__init__.py
+++ b/potassium/__init__.py
@@ -1,3 +1,3 @@
 from .potassium import *
 from .hooks import *
-from .store import Store
+from .store import Store, RedisConfig

--- a/potassium/potassium.py
+++ b/potassium/potassium.py
@@ -4,7 +4,7 @@ from werkzeug.serving import make_server
 from threading import Thread, Lock
 import functools
 from termcolor import colored
-from queue import Queue
+from queue import Queue, Full
 
 class Endpoint():
     def __init__(self, type, func, gpu):
@@ -83,7 +83,10 @@ class Potassium():
                     return res
                 with self._lock:
                     response = endpoint.func(req).json
-                self.event_chan.put(item = True, block=False)
+                try:
+                    self.event_chan.put(item = True, block=False)
+                except Full:
+                    pass
 
             else:
                 response = endpoint.func(req).json
@@ -110,7 +113,10 @@ class Potassium():
                 if endpoint.gpu:
                     with lock:
                         endpoint.func(req)
-                    self.event_chan.put(item = True, block=False)
+                    try:
+                        self.event_chan.put(item = True, block=False)
+                    except Full:
+                        pass
                 else:
                     endpoint.func(req)
                 # we currently do nothing with the response

--- a/potassium/requirements.txt
+++ b/potassium/requirements.txt
@@ -1,3 +1,4 @@
 Flask
 requests
 termcolor
+redis

--- a/potassium/store.py
+++ b/potassium/store.py
@@ -1,17 +1,41 @@
 import time, os
+from typing import Union
 import shelve
 from threading import Thread, Lock
 import atexit
+import redis
+import pickle
+import json
 
 
 class Entry():
     def __init__(self, value, expiration):
         self.value = value
         self.expiration = expiration
-
+class RedisConfig():
+    def __init__(self, host:str, port:str, username:str = None, password:str = None, db:int = 0, encoding:str = "json"):
+        "encoding can be 'json' or 'pickle'. JSON is default.\nPickle has better support for arbitrary python types, but using pickle with a remote redis introduces a large security risk, see https://stackoverflow.com/questions/2259270/pickle-or-json/2259351#2259351"
+        # validate args
+        encodings = ["json", "pickle"]
+        if encoding not in encodings:
+            raise ValueError("redis config encoding must be one of the following:", encodings)
+        
+        self.host = host
+        self.port = port
+        self.username = username
+        self.password = password
+        self.db = db
+        self.encoding = encoding
 class Store():
-    def __init__(self, backend="local"):
+    def __init__(self, backend: str ="local", config: Union[None, RedisConfig] = None):
+        # validate args
+        backends = ["local", "redis"]
+        if backend not in backends:
+            raise ValueError("backend must be one of the following:", backends)
+        
         self.backend = backend
+        self.config = config
+         
         if self.backend == "local": 
             self._local_store = shelve.open(".localstore")
             self._lock = Lock()
@@ -25,6 +49,17 @@ class Store():
             def exit_handler():
                 os.remove(".localstore")
             atexit.register(exit_handler)
+
+        if self.backend == "redis":
+            if not isinstance(config, RedisConfig):
+                raise ValueError("redis backends require users to bring their own redis, and configure the potassium store to use it with the config argument. For example, to use a local redis, create store with:\n\nfrom potassium.store import Store, RedisConfig\nstore = Store(backend = 'redis', config = RedisConfig(host = 'localhost', port = 6379))")
+            self._redis_store = redis.Redis(
+                host=config.host, 
+                port=config.port,
+                username=config.username,
+                password=config.password,
+                db=config.db,
+            )
 
     def _gc(self):
         if self.backend == "local":
@@ -45,6 +80,15 @@ class Store():
             if entry == None:
                 return None
             return entry.value
+        
+        if self.backend == "redis":
+            encoded = self._redis_store.get(key)
+            if encoded == None:
+                return None
+            if self.config.encoding == "json":
+                return json.loads(encoded)
+            if self.config.encoding == "pickle":
+                return pickle.loads(encoded)
     
     def set(self, key, value, ttl=600):
         if self.backend == "local":
@@ -53,3 +97,10 @@ class Store():
                     value=value,
                     expiration=time.time()+ttl
                 )
+
+        if self.backend == "redis":
+            if self.config.encoding == "json":
+                encoded = json.dumps(value)
+            if self.config.encoding == "pickle":
+                encoded = pickle.dumps(value)
+            self._redis_store.set(key, encoded, ex=ttl)

--- a/potassium/store_test.py
+++ b/potassium/store_test.py
@@ -1,0 +1,70 @@
+from store import Store, RedisConfig
+
+# Redis store can save json serializeable objects
+store = Store(
+    backend="redis", 
+    config = RedisConfig(
+        host = "localhost", 
+        port = 6379
+    )
+)
+
+objs = [
+    "1",
+    True,
+    ["some", "list"],
+    {"some": {"nested": "dict"}}
+]
+
+print("Testing json redis")
+for obj in objs:
+    store.set("key", obj)
+    out = store.get("key")
+    if out != obj:
+        print("failed case", obj)
+
+# ----
+
+# pickle redis and localstore can save complex objects
+
+class Complex():
+    def __init__(self, a) -> None:
+        self.a = a
+    def __eq__ (self, other): # necessary for the equal assert later
+        return self.a == other.a
+
+objs = [
+    "1",
+    True,
+    ["some", "list"],
+    {"some": {"nested": "dict"}},
+    Complex(a = 1)
+]
+
+store = Store(
+    backend="redis", 
+    config = RedisConfig(
+        host = "localhost", 
+        port = 6379,
+        encoding = "pickle"
+    )
+)
+
+print("Testing pickle redis")
+for obj in objs:
+    store.set("key", obj)
+    out = store.get("key")
+    if obj != obj:
+        print("failed case", obj)
+
+# local store can save complex objects
+store = Store()
+
+print("Testing local store")
+for obj in objs:
+    store.set("key", obj)
+    out = store.get("key")
+    if out != obj:
+        print("failed case", obj)
+
+


### PR DESCRIPTION
# What is this?
Adds redis backend to the potassium Store utility
- bonus utility: ability to select json or pickle as the encoding method

# Why?
So replicas may synchronize with a shared redis

# How did you test to ensure no regressions?
Tested these cases (unit test added)
- localstore
- local redis w/ json encoding
- local redis w/ pickle encoding
- remote redis

# If this is a new feature what is one way you can make this break?
RedisConfig requires values for host and port, and we don't handle cases where users input invalid values there, so it'd be the redis client errors that bubble up rather than potassium errors.