### PR TITLE
Feature/try catch

### DIFF
--- a/potassium/potassium.py
+++ b/potassium/potassium.py
@@ -5,6 +5,8 @@ from threading import Thread, Lock
 import functools
 from queue import Queue, Full
 import traceback
+from termcolor import colored
+
 
 class Endpoint():
     def __init__(self, type, func, gpu):
@@ -73,6 +75,7 @@ class Potassium():
                 json = flask_request.get_json()
             )
 
+            failed = False
             # run in gpu lock by default
             if endpoint.gpu:
             

--- a/potassium/potassium.py
+++ b/potassium/potassium.py
@@ -4,6 +4,10 @@ from werkzeug.serving import make_server
 from threading import Thread, Lock
 import functools
 from termcolor import colored
+from queue import Queue
+import traceback
+
+
 
 class Endpoint():
     def __init__(self, type, func, gpu):
@@ -30,6 +34,7 @@ class Potassium():
         self.endpoints = {} # dictionary to store unlimited Endpoints, by unique route
         self.context = {}
         self._lock = Lock()
+        self.event_chan = Queue(maxsize=1)
 
     # init runs once on server start
     def init(self, func): 
@@ -80,7 +85,15 @@ class Potassium():
                     res.headers['X-Endpoint-Type'] = endpoint.type
                     return res
                 with self._lock:
-                    response = endpoint.func(req).json
+                    try:
+                        response = endpoint.func(req).json
+                        self.event_chan.put(item=True, block=False)
+                    except:
+                        
+                        tb_str = traceback.format_exc()
+                        response = tb_str
+
+                        self.event_chan.put(item = True, block=False)
 
             else:
                 response = endpoint.func(req).json
@@ -117,6 +130,9 @@ class Potassium():
             res = make_response({"started": True})
             res.headers['X-Endpoint-Type'] = endpoint.type
             return res
+    
+    def read_event_chan(self) -> bool:
+        return self.event_chan.get()
         
     def is_working(self):
         return self._lock.locked()


### PR DESCRIPTION
# What is this?
Try-catch block around the execution of the handlers to 1. get the stack trace as a return message 2. not to have the app itself crash if there's an error

# Why?

# How did you test to ensure no regressions?
Ran locally

# If this is a new feature what is one way you can make this break?
Possible errors in nested indents, but I think I got them right.