### PR TITLE
Cleaner error msg for response objects

### DIFF
--- a/potassium/potassium.py
+++ b/potassium/potassium.py
@@ -101,8 +101,8 @@ class Potassium():
                         res.headers['X-Endpoint-Type'] = endpoint.type
                         return res
                     except:
-                        tb_str = traceback.format_exc()
-                        res = make_response(tb_str)
+                        error_message = f"Unable to create valid Potassium Response, please ensure your Response objects contain valid json, status code)"
+                        res = make_response(error_message)
                         res.status_code = 500
                         res.headers['X-Endpoint-Type'] = endpoint.type
                         return res

--- a/potassium/potassium.py
+++ b/potassium/potassium.py
@@ -96,13 +96,21 @@ class Potassium():
                 with self._lock:
                     try:
                         out = endpoint.func(req)
+                        if type(out) != Response:
+                            raise Exception("Potassium Response object not returned")
+
+                        # check if out.json is a dict
+                        if type(out.json) != dict:
+                            raise Exception("Potassium Response object json must be a dict")
+    
                         res = make_response(out.json)
                         res.status_code = out.status
                         res.headers['X-Endpoint-Type'] = endpoint.type
                         return res
                     except:
-                        error_message = f"Unable to create valid Potassium Response, please ensure your Response objects contain valid json, status code)"
-                        res = make_response(error_message)
+                        tb_str = traceback.format_exc()
+                        print(tb_str)
+                        res = make_response(tb_str)
                         res.status_code = 500
                         res.headers['X-Endpoint-Type'] = endpoint.type
                         return res
@@ -110,6 +118,15 @@ class Potassium():
             else:
                 try:
                     out = endpoint.func(req)
+
+                    if type(out) != Response:
+                        raise Exception("Potassium Response object not returned")
+
+                        # check if out.json is a dict
+                    if type(out.json) != dict:
+                        raise Exception("Potassium Response object json must be a dict")
+
+
                     res = make_response(out.json)
                     res.status_code = out.status
                     res.headers['X-Endpoint-Type'] = endpoint.type

--- a/potassium/potassium.py
+++ b/potassium/potassium.py
@@ -55,8 +55,20 @@ class Potassium():
             def wrapper(request):
                 # send in app's stateful context if GPU, and the request
                 if gpu:
-                    return func(self._context, request)
-                return func(None, request)
+                    out = func(self._context, request)
+                else:
+                    out = func(None, request)
+
+                if type(out) != Response:
+                    raise Exception("Potassium Response object not returned")
+
+                # check if out.json is a dict
+                if type(out.json) != dict:
+                    raise Exception("Potassium Response object json must be a dict")
+
+                return out
+
+ 
             self._endpoints[route] = Endpoint(
                 type="handler", func=wrapper, gpu=gpu)
             return wrapper
@@ -70,7 +82,9 @@ class Potassium():
                 # send in app's stateful context if GPU, and the request
                 if gpu:
                     return func(self._context, request)
-                return func(None, request)
+                else:
+                    return func(None, request)
+
             self._endpoints[route] = Endpoint(
                 type="background", func=wrapper, gpu=gpu)
             return wrapper
@@ -96,20 +110,12 @@ class Potassium():
                 with self._lock:
                     try:
                         out = endpoint.func(req)
-                        if type(out) != Response:
-                            raise Exception("Potassium Response object not returned")
-
-                        # check if out.json is a dict
-                        if type(out.json) != dict:
-                            raise Exception("Potassium Response object json must be a dict")
-    
                         res = make_response(out.json)
                         res.status_code = out.status
                         res.headers['X-Endpoint-Type'] = endpoint.type
                         return res
                     except:
                         tb_str = traceback.format_exc()
-                        print(tb_str)
                         res = make_response(tb_str)
                         res.status_code = 500
                         res.headers['X-Endpoint-Type'] = endpoint.type
@@ -118,15 +124,6 @@ class Potassium():
             else:
                 try:
                     out = endpoint.func(req)
-
-                    if type(out) != Response:
-                        raise Exception("Potassium Response object not returned")
-
-                        # check if out.json is a dict
-                    if type(out.json) != dict:
-                        raise Exception("Potassium Response object json must be a dict")
-
-
                     res = make_response(out.json)
                     res.status_code = out.status
                     res.headers['X-Endpoint-Type'] = endpoint.type

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ long_description = (this_directory / "README.md").read_text()
 setup(
     name='potassium',
     packages=['potassium'],
-    version='0.0.9',
+    version='0.0.10',
     license='Apache License 2.0',
     # Give a short description about your library
     description='The potassium package is a flask-like HTTP server for serving large AI models',


### PR DESCRIPTION
# What is this?
Simpler error message if Response is formatted wrong

# Why?
Original msg was cryptic and caused me confusion.

**Before**
`TypeError: The view function did not return a valid response. The return type must be a string, dict, list, tuple with headers or status, Response instance, or WSGI callable, but it was a set.`

**Now**
Unable to create valid Potassium Response, please ensure your Response objects contain valid json, status code)

# How did you test it works without  regressions?
Tested local with failed json return, tested with np array return (threw expected error json can't be serialized), success case returns

# If this is a new feature what may a critical error (P0) look like?
N/a given it's already an exception being thrown. 

### Things to consider to not repeat mistakes we've learned from many times
- [ ] If P0 errors fire do we ping team in some obvious way (e.g., slack)? 
- [x] Are there debug logs + a way to see these logs if we need to debug?
- [x] Is this documented enough a dev could work on this code without getting stuck or having to ping you?
