### PR TITLE
Deprecate/cpu endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# vscode
+.vscode

--- a/README.md
+++ b/README.md
@@ -37,12 +37,13 @@ This downloads boilerplate for your potassium app, and automatically installs po
 banana init my-app
 cd my-app
 ```
-3. Start the hot-reload dev server
+1. Start the dev server
 ```bash
-banana dev
+. ./venv/bin/activate
+python3 app.py
 ```
 
-4. Call your API (from a separate terminal)
+1. Call your API (from a separate terminal)
 ```bash
 curl -X POST -H "Content-Type: application/json" -d '{"prompt": "Hello I am a [MASK] model."}' http://localhost:8000/
 ``` 
@@ -161,7 +162,7 @@ There may only be one `@app.init` function.
 ## @app.handler()
 
 ```python
-@app.handler("/", gpu=True)
+@app.handler("/")
 def handler(context: dict, request: Request) -> Response:
     
     prompt = request.json.get("prompt")
@@ -178,11 +179,9 @@ The `@app.handler` decorated function runs for every http call, and is used to r
 
 You may configure as many `@app.handler` functions as you'd like, with unique API routes.
 
-The `gpu=True` argument allows the handler to access the prewarmed context value, and runs the handler as blocking. While the handler is running, potassium will reject any other `gpu=True` handlers with a 423 Locked error, to ensure that there are no multithreading issues with CUDA. If set to `false`, the handler may be called at any time, but the context provided will be `None`. `gpu` defaults to `True`.
-
 ---
 
-## @app.background(path="/background", gpu=True)
+## @app.background(path="/background")
 
 ```python
 @app.background("/background")
@@ -199,11 +198,9 @@ def handler(context: dict, request: Request) -> Response:
 
 The `@app.background()` decorated function runs a nonblocking job in the background, for tasks where results aren't expected to return clientside. It's on you to forward the data to wherever you please. Potassium supplies a `send_webhook()` helper function for POSTing data onward to a url, or you may add your own custom upload/pipeline code.
 
-When invoked, the client immediately returns a `{"success": true}` message.
+When invoked, the server immediately returns a `{"success": true}` message.
 
 You may configure as many `@app.background` functions as you'd like, with unique API routes.
-
-The `gpu=True` argument allows the background handler to access the prewarmed context value, and runs the child background thread as blocking. While the child thread is running, potassium will reject any other `gpu=True` handlers with a 423 Locked error, to ensure that there are no multithreading issues with CUDA. If set to `false`, the handler may be called at any time, but the context provided will be `None`. `gpu` defaults to `True`.
 
 ---
 
@@ -215,7 +212,7 @@ The `gpu=True` argument allows the background handler to access the prewarmed co
 ---
 
 # Store
-Potassium includes a key-value storage primative, to help users persist data between calls. This is often used to implement patterns such as an async-worker queue where one background task runs inference and saves the result to the Store, with another handler set to `gpu=False` built to fetch the result.
+Potassium includes a key-value storage primative, to help users persist data between calls.
 
 Example usage: your own Redis backend (encouraged)
 ```

--- a/example.py
+++ b/example.py
@@ -6,11 +6,13 @@ import time
 app = Potassium("my_app")
 
 # @app.init runs at startup, and initializes the app's context
+
+
 @app.init
 def init():
     device = 0 if torch.cuda.is_available() else -1
     model = pipeline('fill-mask', model='bert-base-uncased', device=device)
-   
+
     context = {
         "model": model,
         "hello": "world"
@@ -18,30 +20,19 @@ def init():
 
     return context
 
+
 @app.handler()
 def handler(context: dict, request: Request) -> Response:
-    
+
     prompt = request.json.get("prompt")
     model = context.get("model")
     outputs = model(prompt)
 
     return Response(
-        json = {"outputs": outputs}, 
+        json={"outputs": outputs},
         status=200
     )
 
-@app.async_handler("/async")
-def handler(context: dict, request: Request) -> Response:
-
-    time.sleep(2)
-
-    prompt = request.json.get("prompt")
-    model = context.get("model")
-    outputs = model(prompt)
-
-    send_webhook(url="http://localhost:8001", json={"outputs": outputs})
-
-    return
 
 if __name__ == "__main__":
     app.serve()

--- a/potassium/potassium.py
+++ b/potassium/potassium.py
@@ -9,20 +9,18 @@ from termcolor import colored
 
 
 class Endpoint():
-    def __init__(self, type, func, gpu):
+    def __init__(self, type, func):
         self.type = type
         self.func = func
-        self.gpu = gpu
 
 
 class Request():
-    def __init__(self, json: dict, ws=None):
+    def __init__(self, json: dict):
         self.json = json
-        self.ws = ws
 
 
 class Response():
-    def __init__(self, status:int = 200, json: dict = {}):
+    def __init__(self, status: int = 200, json: dict = {}):
         self.json = json
         self.status = status
 
@@ -33,7 +31,7 @@ class Potassium():
 
         def default_func():
             return
-        
+
         # semi-private vars, not intended for users to modify
         self._init_func = default_func
         self._endpoints = {}  # dictionary to store unlimited Endpoints, by unique route
@@ -49,79 +47,56 @@ class Potassium():
         return wrapper
 
     # handler is a blocking http POST handler
-    def handler(self, route: str = "/", gpu: bool = True):
+    def handler(self, route: str = "/"):
         def actual_decorator(func):
             @functools.wraps(func)
             def wrapper(request):
                 # send in app's stateful context if GPU, and the request
-                if gpu:
-                    out = func(self._context, request)
-                else:
-                    out = func(None, request)
+                out = func(self._context, request)
 
                 if type(out) != Response:
                     raise Exception("Potassium Response object not returned")
 
                 # check if out.json is a dict
                 if type(out.json) != dict:
-                    raise Exception("Potassium Response object json must be a dict")
+                    raise Exception(
+                        "Potassium Response object json must be a dict")
 
                 return out
 
- 
-            self._endpoints[route] = Endpoint(
-                type="handler", func=wrapper, gpu=gpu)
+            self._endpoints[route] = Endpoint(type="handler", func=wrapper)
             return wrapper
         return actual_decorator
 
     # background is a non-blocking http POST handler
-    def background(self, route: str = "/", gpu: bool = True):
+    def background(self, route: str = "/"):
         def actual_decorator(func):
             @functools.wraps(func)
             def wrapper(request):
                 # send in app's stateful context if GPU, and the request
-                if gpu:
-                    return func(self._context, request)
-                else:
-                    return func(None, request)
+                return func(self._context, request)
 
             self._endpoints[route] = Endpoint(
-                type="background", func=wrapper, gpu=gpu)
+                type="background", func=wrapper)
             return wrapper
         return actual_decorator
 
     # _handle_generic takes in a request and the endpoint it was routed to and handles it as expected by that endpoint
     def _handle_generic(self, route, endpoint, flask_request):
 
+        # potassium rejects if lock already in use
+        if self._is_working():
+            res = make_response()
+            res.status_code = 423
+            res.headers['X-Endpoint-Type'] = endpoint.type
+            return res
+
         if endpoint.type == "handler":
             req = Request(
                 json=flask_request.get_json()
             )
 
-            # run in gpu lock by default
-            if endpoint.gpu:
-                # gpu rejects if lock already in use
-                if self._is_working():
-                    res = make_response()
-                    res.status_code = 423
-                    res.headers['X-Endpoint-Type'] = endpoint.type
-                    return res
-
-                with self._lock:
-                    try:
-                        out = endpoint.func(req)
-                        res = make_response(out.json)
-                        res.status_code = out.status
-                        res.headers['X-Endpoint-Type'] = endpoint.type
-                        return res
-                    except:
-                        tb_str = traceback.format_exc()
-                        res = make_response(tb_str)
-                        res.status_code = 500
-                        res.headers['X-Endpoint-Type'] = endpoint.type
-                        return res
-
-            else:
+            with self._lock:
                 try:
                     out = endpoint.func(req)
                     res = make_response(out.json)
@@ -140,32 +115,16 @@ class Potassium():
                 json=flask_request.get_json()
             )
 
-            if endpoint.gpu:
-                # gpu rejects if lock already in use
-                if self._is_working():
-                    res = make_response()
-                    res.status_code = 423
-                    res.headers['X-Endpoint-Type'] = endpoint.type
-                    return res
-
             # run as threaded task
             def task(endpoint, lock, req):
-                if endpoint.gpu:
-                    with lock:
-                        try:
-                            endpoint.func(req)
-                        except Exception as e:
-                            # do any cleanup before re-raising user error
-                            self._write_event_chan(True)
-                            raise e
-                    self._write_event_chan(True)
-                else:
+                with lock:
                     try:
                         endpoint.func(req)
                     except Exception as e:
                         # do any cleanup before re-raising user error
-                        # in this case, there is no cleanup
+                        self._write_event_chan(True)
                         raise e
+                self._write_event_chan(True)
 
             thread = Thread(target=task, args=(endpoint, self._lock, req))
             thread.start()

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ long_description = (this_directory / "README.md").read_text()
 setup(
     name='potassium',
     packages=['potassium'],
-    version='0.0.10',
+    version='0.1.0',
     license='Apache License 2.0',
     # Give a short description about your library
     description='The potassium package is a flask-like HTTP server for serving large AI models',


### PR DESCRIPTION
# What is this?
Removes CPU endpoints from handler defs

# Why?
1. not a crystal clear differentiation between CPU and gpu handlers + naming didn't help
2. added too much complexity. We at Banana need to focus on doing one thing really well. Adding the noise of cpu statefulness was not something we wanted to support.

# How did you test it works without regressions?
will test staging -> main merge

# If this is a new feature what may a critical error (P0) look like? 
This is a breaking change but not a major version bump as we've already communicated that v0 is an unstable major version.
