### PR TITLE
Deprecate/localstore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# vscode
+.vscode

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ This downloads boilerplate for your potassium app, and automatically installs po
 banana init my-app
 cd my-app
 ```
-1. Start the dev server
+3. Start the dev server
 ```bash
 . ./venv/bin/activate
 python3 app.py
 ```
 
-1. Call your API (from a separate terminal)
+4. Call your API (from a separate terminal)
 ```bash
 curl -X POST -H "Content-Type: application/json" -d '{"prompt": "Hello I am a [MASK] model."}' http://localhost:8000/
 ``` 

--- a/README.md
+++ b/README.md
@@ -37,12 +37,13 @@ This downloads boilerplate for your potassium app, and automatically installs po
 banana init my-app
 cd my-app
 ```
-3. Start the hot-reload dev server
+1. Start the dev server
 ```bash
-banana dev
+. ./venv/bin/activate
+python3 app.py
 ```
 
-4. Call your API (from a separate terminal)
+1. Call your API (from a separate terminal)
 ```bash
 curl -X POST -H "Content-Type: application/json" -d '{"prompt": "Hello I am a [MASK] model."}' http://localhost:8000/
 ``` 
@@ -161,7 +162,7 @@ There may only be one `@app.init` function.
 ## @app.handler()
 
 ```python
-@app.handler("/", gpu=True)
+@app.handler("/")
 def handler(context: dict, request: Request) -> Response:
     
     prompt = request.json.get("prompt")
@@ -178,11 +179,9 @@ The `@app.handler` decorated function runs for every http call, and is used to r
 
 You may configure as many `@app.handler` functions as you'd like, with unique API routes.
 
-The `gpu=True` argument allows the handler to access the prewarmed context value, and runs the handler as blocking. While the handler is running, potassium will reject any other `gpu=True` handlers with a 423 Locked error, to ensure that there are no multithreading issues with CUDA. If set to `false`, the handler may be called at any time, but the context provided will be `None`. `gpu` defaults to `True`.
-
 ---
 
-## @app.background(path="/background", gpu=True)
+## @app.background(path="/background")
 
 ```python
 @app.background("/background")
@@ -199,11 +198,9 @@ def handler(context: dict, request: Request) -> Response:
 
 The `@app.background()` decorated function runs a nonblocking job in the background, for tasks where results aren't expected to return clientside. It's on you to forward the data to wherever you please. Potassium supplies a `send_webhook()` helper function for POSTing data onward to a url, or you may add your own custom upload/pipeline code.
 
-When invoked, the client immediately returns a `{"success": true}` message.
+When invoked, the server immediately returns a `{"success": true}` message.
 
 You may configure as many `@app.background` functions as you'd like, with unique API routes.
-
-The `gpu=True` argument allows the background handler to access the prewarmed context value, and runs the child background thread as blocking. While the child thread is running, potassium will reject any other `gpu=True` handlers with a 423 Locked error, to ensure that there are no multithreading issues with CUDA. If set to `false`, the handler may be called at any time, but the context provided will be `None`. `gpu` defaults to `True`.
 
 ---
 
@@ -215,7 +212,7 @@ The `gpu=True` argument allows the background handler to access the prewarmed co
 ---
 
 # Store
-Potassium includes a key-value storage primative, to help users persist data between calls. This is often used to implement patterns such as an async-worker queue where one background task runs inference and saves the result to the Store, with another handler set to `gpu=False` built to fetch the result.
+Potassium includes a key-value storage primative, to help users persist data between calls.
 
 Example usage: your own Redis backend (encouraged)
 ```

--- a/example.py
+++ b/example.py
@@ -6,11 +6,13 @@ import time
 app = Potassium("my_app")
 
 # @app.init runs at startup, and initializes the app's context
+
+
 @app.init
 def init():
     device = 0 if torch.cuda.is_available() else -1
     model = pipeline('fill-mask', model='bert-base-uncased', device=device)
-   
+
     context = {
         "model": model,
         "hello": "world"
@@ -18,30 +20,19 @@ def init():
 
     return context
 
+
 @app.handler()
 def handler(context: dict, request: Request) -> Response:
-    
+
     prompt = request.json.get("prompt")
     model = context.get("model")
     outputs = model(prompt)
 
     return Response(
-        json = {"outputs": outputs}, 
+        json={"outputs": outputs},
         status=200
     )
 
-@app.async_handler("/async")
-def handler(context: dict, request: Request) -> Response:
-
-    time.sleep(2)
-
-    prompt = request.json.get("prompt")
-    model = context.get("model")
-    outputs = model(prompt)
-
-    send_webhook(url="http://localhost:8001", json={"outputs": outputs})
-
-    return
 
 if __name__ == "__main__":
     app.serve()

--- a/potassium/potassium.py
+++ b/potassium/potassium.py
@@ -9,20 +9,18 @@ from termcolor import colored
 
 
 class Endpoint():
-    def __init__(self, type, func, gpu):
+    def __init__(self, type, func):
         self.type = type
         self.func = func
-        self.gpu = gpu
 
 
 class Request():
-    def __init__(self, json: dict, ws=None):
+    def __init__(self, json: dict):
         self.json = json
-        self.ws = ws
 
 
 class Response():
-    def __init__(self, status:int = 200, json: dict = {}):
+    def __init__(self, status: int = 200, json: dict = {}):
         self.json = json
         self.status = status
 
@@ -33,7 +31,7 @@ class Potassium():
 
         def default_func():
             return
-        
+
         # semi-private vars, not intended for users to modify
         self._init_func = default_func
         self._endpoints = {}  # dictionary to store unlimited Endpoints, by unique route
@@ -49,79 +47,56 @@ class Potassium():
         return wrapper
 
     # handler is a blocking http POST handler
-    def handler(self, route: str = "/", gpu: bool = True):
+    def handler(self, route: str = "/"):
         def actual_decorator(func):
             @functools.wraps(func)
             def wrapper(request):
                 # send in app's stateful context if GPU, and the request
-                if gpu:
-                    out = func(self._context, request)
-                else:
-                    out = func(None, request)
+                out = func(self._context, request)
 
                 if type(out) != Response:
                     raise Exception("Potassium Response object not returned")
 
                 # check if out.json is a dict
                 if type(out.json) != dict:
-                    raise Exception("Potassium Response object json must be a dict")
+                    raise Exception(
+                        "Potassium Response object json must be a dict")
 
                 return out
 
- 
-            self._endpoints[route] = Endpoint(
-                type="handler", func=wrapper, gpu=gpu)
+            self._endpoints[route] = Endpoint(type="handler", func=wrapper)
             return wrapper
         return actual_decorator
 
     # background is a non-blocking http POST handler
-    def background(self, route: str = "/", gpu: bool = True):
+    def background(self, route: str = "/"):
         def actual_decorator(func):
             @functools.wraps(func)
             def wrapper(request):
                 # send in app's stateful context if GPU, and the request
-                if gpu:
-                    return func(self._context, request)
-                else:
-                    return func(None, request)
+                return func(self._context, request)
 
             self._endpoints[route] = Endpoint(
-                type="background", func=wrapper, gpu=gpu)
+                type="background", func=wrapper)
             return wrapper
         return actual_decorator
 
     # _handle_generic takes in a request and the endpoint it was routed to and handles it as expected by that endpoint
     def _handle_generic(self, route, endpoint, flask_request):
 
+        # potassium rejects if lock already in use
+        if self._is_working():
+            res = make_response()
+            res.status_code = 423
+            res.headers['X-Endpoint-Type'] = endpoint.type
+            return res
+
         if endpoint.type == "handler":
             req = Request(
                 json=flask_request.get_json()
             )
 
-            # run in gpu lock by default
-            if endpoint.gpu:
-                # gpu rejects if lock already in use
-                if self._is_working():
-                    res = make_response()
-                    res.status_code = 423
-                    res.headers['X-Endpoint-Type'] = endpoint.type
-                    return res
-
-                with self._lock:
-                    try:
-                        out = endpoint.func(req)
-                        res = make_response(out.json)
-                        res.status_code = out.status
-                        res.headers['X-Endpoint-Type'] = endpoint.type
-                        return res
-                    except:
-                        tb_str = traceback.format_exc()
-                        res = make_response(tb_str)
-                        res.status_code = 500
-                        res.headers['X-Endpoint-Type'] = endpoint.type
-                        return res
-
-            else:
+            with self._lock:
                 try:
                     out = endpoint.func(req)
                     res = make_response(out.json)
@@ -140,32 +115,16 @@ class Potassium():
                 json=flask_request.get_json()
             )
 
-            if endpoint.gpu:
-                # gpu rejects if lock already in use
-                if self._is_working():
-                    res = make_response()
-                    res.status_code = 423
-                    res.headers['X-Endpoint-Type'] = endpoint.type
-                    return res
-
             # run as threaded task
             def task(endpoint, lock, req):
-                if endpoint.gpu:
-                    with lock:
-                        try:
-                            endpoint.func(req)
-                        except Exception as e:
-                            # do any cleanup before re-raising user error
-                            self._write_event_chan(True)
-                            raise e
-                    self._write_event_chan(True)
-                else:
+                with lock:
                     try:
                         endpoint.func(req)
                     except Exception as e:
                         # do any cleanup before re-raising user error
-                        # in this case, there is no cleanup
+                        self._write_event_chan(True)
                         raise e
+                self._write_event_chan(True)
 
             thread = Thread(target=task, args=(endpoint, self._lock, req))
             thread.start()

--- a/potassium/store.py
+++ b/potassium/store.py
@@ -1,4 +1,5 @@
-import time, os
+import time
+import os
 from typing import Union
 import shelve
 from threading import Thread, Lock
@@ -12,75 +13,47 @@ class Entry():
     def __init__(self, value, expiration):
         self.value = value
         self.expiration = expiration
+
+
 class RedisConfig():
-    def __init__(self, host:str, port:str, username:str = None, password:str = None, db:int = 0, encoding:str = "json"):
+    def __init__(self, host: str, port: str, username: str = None, password: str = None, db: int = 0, encoding: str = "json"):
         "encoding can be 'json' or 'pickle'. JSON is default.\nPickle has better support for arbitrary python types, but using pickle with a remote redis introduces a large security risk, see https://stackoverflow.com/questions/2259270/pickle-or-json/2259351#2259351"
         # validate args
         encodings = ["json", "pickle"]
         if encoding not in encodings:
-            raise ValueError("redis config encoding must be one of the following:", encodings)
-        
+            raise ValueError(
+                "redis config encoding must be one of the following:", encodings)
+
         self.host = host
         self.port = port
         self.username = username
         self.password = password
         self.db = db
         self.encoding = encoding
+
+
 class Store():
-    def __init__(self, backend: str ="local", config: Union[None, RedisConfig] = None):
+    def __init__(self, backend: str = "redis", config: Union[None, RedisConfig] = None):
         # validate args
-        backends = ["local", "redis"]
+        backends = ["redis"]
         if backend not in backends:
             raise ValueError("backend must be one of the following:", backends)
-        
+
         self.backend = backend
         self.config = config
-         
-        if self.backend == "local": 
-            self._local_store = shelve.open(".localstore")
-            self._lock = Lock()
-            
-            # run TTL gc as thread
-            thread = Thread(target=self._gc)
-            thread.daemon = True
-            thread.start()
-
-            # delete store at exit, to avoid side effects
-            def exit_handler():
-                os.remove(".localstore")
-            atexit.register(exit_handler)
 
         if self.backend == "redis":
             if not isinstance(config, RedisConfig):
                 raise ValueError("redis backends require users to bring their own redis, and configure the potassium store to use it with the config argument. For example, to use a local redis, create store with:\n\nfrom potassium.store import Store, RedisConfig\nstore = Store(backend = 'redis', config = RedisConfig(host = 'localhost', port = 6379))")
             self._redis_store = redis.Redis(
-                host=config.host, 
+                host=config.host,
                 port=config.port,
                 username=config.username,
                 password=config.password,
                 db=config.db,
             )
 
-    def _gc(self):
-        if self.backend == "local":
-            while True:
-                time.sleep(1)
-                with self._lock:
-                    try:
-                        for k, v in self._local_store.items():
-                            if v.expiration < time.time():
-                                del self._local_store[k]
-                    except:
-                        pass
-
     def get(self, key: str):
-        if self.backend == "local":
-            with self._lock:
-                entry = self._local_store.get(key)
-            if entry == None:
-                return None
-            return entry.value
-        
         if self.backend == "redis":
             encoded = self._redis_store.get(key)
             if encoded == None:
@@ -89,15 +62,8 @@ class Store():
                 return json.loads(encoded)
             if self.config.encoding == "pickle":
                 return pickle.loads(encoded)
-    
-    def set(self, key, value, ttl=600):
-        if self.backend == "local":
-            with self._lock:
-                self._local_store[key] = Entry(
-                    value=value,
-                    expiration=time.time()+ttl
-                )
 
+    def set(self, key, value, ttl=600):
         if self.backend == "redis":
             if self.config.encoding == "json":
                 encoded = json.dumps(value)

--- a/potassium/store_test.py
+++ b/potassium/store_test.py
@@ -2,10 +2,10 @@ from store import Store, RedisConfig
 
 # Redis store can save json serializeable objects
 store = Store(
-    backend="redis", 
-    config = RedisConfig(
-        host = "localhost", 
-        port = 6379
+    backend="redis",
+    config=RedisConfig(
+        host="localhost",
+        port=6379
     )
 )
 
@@ -25,28 +25,31 @@ for obj in objs:
 
 # ----
 
-# pickle redis and localstore can save complex objects
+# pickle redis can save complex objects
+
 
 class Complex():
     def __init__(self, a) -> None:
         self.a = a
-    def __eq__ (self, other): # necessary for the equal assert later
+
+    def __eq__(self, other):  # necessary for the equal assert later
         return self.a == other.a
+
 
 objs = [
     "1",
     True,
     ["some", "list"],
     {"some": {"nested": "dict"}},
-    Complex(a = 1)
+    Complex(a=1)
 ]
 
 store = Store(
-    backend="redis", 
-    config = RedisConfig(
-        host = "localhost", 
-        port = 6379,
-        encoding = "pickle"
+    backend="redis",
+    config=RedisConfig(
+        host="localhost",
+        port=6379,
+        encoding="pickle"
     )
 )
 
@@ -56,15 +59,3 @@ for obj in objs:
     out = store.get("key")
     if obj != obj:
         print("failed case", obj)
-
-# local store can save complex objects
-store = Store()
-
-print("Testing local store")
-for obj in objs:
-    store.set("key", obj)
-    out = store.get("key")
-    if out != obj:
-        print("failed case", obj)
-
-

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ long_description = (this_directory / "README.md").read_text()
 setup(
     name='potassium',
     packages=['potassium'],
-    version='0.0.10',
+    version='0.1.0',
     license='Apache License 2.0',
     # Give a short description about your library
     description='The potassium package is a flask-like HTTP server for serving large AI models',


### PR DESCRIPTION
# What is this?
We remove the local filesystem backend for store

# Why?
It's not useful in a multi-replica, load balanced environment, as file system is ephemeral and not shared, so we don't want to encourage it for use on Banana. Users wanting this functionality for self-hosted potassium should write the file storage or cpu cache themselves.

# How did you test it works without regressions?
Unit tests pass!
