### PR TITLE
Deprecate/localstore

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ This downloads boilerplate for your potassium app, and automatically installs po
 banana init my-app
 cd my-app
 ```
-1. Start the dev server
+3. Start the dev server
 ```bash
 . ./venv/bin/activate
 python3 app.py
 ```
 
-1. Call your API (from a separate terminal)
+4. Call your API (from a separate terminal)
 ```bash
 curl -X POST -H "Content-Type: application/json" -d '{"prompt": "Hello I am a [MASK] model."}' http://localhost:8000/
 ``` 

--- a/potassium/store.py
+++ b/potassium/store.py
@@ -1,4 +1,5 @@
-import time, os
+import time
+import os
 from typing import Union
 import shelve
 from threading import Thread, Lock
@@ -12,75 +13,47 @@ class Entry():
     def __init__(self, value, expiration):
         self.value = value
         self.expiration = expiration
+
+
 class RedisConfig():
-    def __init__(self, host:str, port:str, username:str = None, password:str = None, db:int = 0, encoding:str = "json"):
+    def __init__(self, host: str, port: str, username: str = None, password: str = None, db: int = 0, encoding: str = "json"):
         "encoding can be 'json' or 'pickle'. JSON is default.\nPickle has better support for arbitrary python types, but using pickle with a remote redis introduces a large security risk, see https://stackoverflow.com/questions/2259270/pickle-or-json/2259351#2259351"
         # validate args
         encodings = ["json", "pickle"]
         if encoding not in encodings:
-            raise ValueError("redis config encoding must be one of the following:", encodings)
-        
+            raise ValueError(
+                "redis config encoding must be one of the following:", encodings)
+
         self.host = host
         self.port = port
         self.username = username
         self.password = password
         self.db = db
         self.encoding = encoding
+
+
 class Store():
-    def __init__(self, backend: str ="local", config: Union[None, RedisConfig] = None):
+    def __init__(self, backend: str = "redis", config: Union[None, RedisConfig] = None):
         # validate args
-        backends = ["local", "redis"]
+        backends = ["redis"]
         if backend not in backends:
             raise ValueError("backend must be one of the following:", backends)
-        
+
         self.backend = backend
         self.config = config
-         
-        if self.backend == "local": 
-            self._local_store = shelve.open(".localstore")
-            self._lock = Lock()
-            
-            # run TTL gc as thread
-            thread = Thread(target=self._gc)
-            thread.daemon = True
-            thread.start()
-
-            # delete store at exit, to avoid side effects
-            def exit_handler():
-                os.remove(".localstore")
-            atexit.register(exit_handler)
 
         if self.backend == "redis":
             if not isinstance(config, RedisConfig):
                 raise ValueError("redis backends require users to bring their own redis, and configure the potassium store to use it with the config argument. For example, to use a local redis, create store with:\n\nfrom potassium.store import Store, RedisConfig\nstore = Store(backend = 'redis', config = RedisConfig(host = 'localhost', port = 6379))")
             self._redis_store = redis.Redis(
-                host=config.host, 
+                host=config.host,
                 port=config.port,
                 username=config.username,
                 password=config.password,
                 db=config.db,
             )
 
-    def _gc(self):
-        if self.backend == "local":
-            while True:
-                time.sleep(1)
-                with self._lock:
-                    try:
-                        for k, v in self._local_store.items():
-                            if v.expiration < time.time():
-                                del self._local_store[k]
-                    except:
-                        pass
-
     def get(self, key: str):
-        if self.backend == "local":
-            with self._lock:
-                entry = self._local_store.get(key)
-            if entry == None:
-                return None
-            return entry.value
-        
         if self.backend == "redis":
             encoded = self._redis_store.get(key)
             if encoded == None:
@@ -89,15 +62,8 @@ class Store():
                 return json.loads(encoded)
             if self.config.encoding == "pickle":
                 return pickle.loads(encoded)
-    
-    def set(self, key, value, ttl=600):
-        if self.backend == "local":
-            with self._lock:
-                self._local_store[key] = Entry(
-                    value=value,
-                    expiration=time.time()+ttl
-                )
 
+    def set(self, key, value, ttl=600):
         if self.backend == "redis":
             if self.config.encoding == "json":
                 encoded = json.dumps(value)

--- a/potassium/store_test.py
+++ b/potassium/store_test.py
@@ -2,10 +2,10 @@ from store import Store, RedisConfig
 
 # Redis store can save json serializeable objects
 store = Store(
-    backend="redis", 
-    config = RedisConfig(
-        host = "localhost", 
-        port = 6379
+    backend="redis",
+    config=RedisConfig(
+        host="localhost",
+        port=6379
     )
 )
 
@@ -25,28 +25,31 @@ for obj in objs:
 
 # ----
 
-# pickle redis and localstore can save complex objects
+# pickle redis can save complex objects
+
 
 class Complex():
     def __init__(self, a) -> None:
         self.a = a
-    def __eq__ (self, other): # necessary for the equal assert later
+
+    def __eq__(self, other):  # necessary for the equal assert later
         return self.a == other.a
+
 
 objs = [
     "1",
     True,
     ["some", "list"],
     {"some": {"nested": "dict"}},
-    Complex(a = 1)
+    Complex(a=1)
 ]
 
 store = Store(
-    backend="redis", 
-    config = RedisConfig(
-        host = "localhost", 
-        port = 6379,
-        encoding = "pickle"
+    backend="redis",
+    config=RedisConfig(
+        host="localhost",
+        port=6379,
+        encoding="pickle"
     )
 )
 
@@ -56,15 +59,3 @@ for obj in objs:
     out = store.get("key")
     if obj != obj:
         print("failed case", obj)
-
-# local store can save complex objects
-store = Store()
-
-print("Testing local store")
-for obj in objs:
-    store.set("key", obj)
-    out = store.get("key")
-    if out != obj:
-        print("failed case", obj)
-
-


### PR DESCRIPTION
# What is this?
We remove the local filesystem backend for store

# Why?
It's not useful in a multi-replica, load balanced environment, as file system is ephemeral and not shared, so we don't want to encourage it for use on Banana. Users wanting this functionality for self-hosted potassium should write the file storage or cpu cache themselves.

# How did you test it works without regressions?
Unit tests pass!
