### PR TITLE
added s3 store

### DIFF
--- a/potassium/requirements.txt
+++ b/potassium/requirements.txt
@@ -2,3 +2,4 @@ Flask
 requests
 termcolor
 redis
+boto3

--- a/potassium/store.py
+++ b/potassium/store.py
@@ -34,7 +34,7 @@ class RedisConfig():
 
 
 class S3Config():
-    def __init__(self, access_key, secret_access_key, bucket, encoding: str = "json"):
+    def __init__(self, aws_access_key_id, aws_secret_access_key, bucket, encoding: str = "json"):
         "encoding can be 'json' or 'pickle'. JSON is default.\nPickle has better support for arbitrary python types, but using pickle across the network to s3 introduces a large security risk, see https://stackoverflow.com/questions/2259270/pickle-or-json/2259351#2259351"
         # validate args
         encodings = ["json", "pickle"]
@@ -42,8 +42,15 @@ class S3Config():
             raise ValueError(
                 "s3 config encoding must be one of the following:", encodings)
 
-        self.access_key = access_key
-        self.secret_access_key = secret_access_key
+        if aws_access_key_id is None:
+            raise ValueError(
+                "aws_access_key_id must be provided. It is a sensitive key, so ensure it is scoped to the bucket you want to use and not hardcoded in any open source repos.")
+        if aws_secret_access_key is None:
+            raise ValueError(
+                "aws_secret_access_key must be provided. It is a sensitive key, so ensure it is scoped to the bucket you want to use and not hardcoded in any open source repos.")
+
+        self.access_key = aws_access_key_id
+        self.secret_access_key = aws_secret_access_key
         self.bucket = bucket
         self.encoding = encoding
 

--- a/potassium/store.py
+++ b/potassium/store.py
@@ -5,6 +5,7 @@ import shelve
 from threading import Thread, Lock
 import atexit
 import redis
+import boto3
 import pickle
 import json
 
@@ -32,10 +33,25 @@ class RedisConfig():
         self.encoding = encoding
 
 
-class Store():
-    def __init__(self, backend: str = "redis", config: Union[None, RedisConfig] = None):
+class S3Config():
+    def __init__(self, access_key, secret_access_key, bucket, encoding: str = "json"):
+        "encoding can be 'json' or 'pickle'. JSON is default.\nPickle has better support for arbitrary python types, but using pickle with a remote redis introduces a large security risk, see https://stackoverflow.com/questions/2259270/pickle-or-json/2259351#2259351"
         # validate args
-        backends = ["redis"]
+        encodings = ["json", "pickle"]
+        if encoding not in encodings:
+            raise ValueError(
+                "s3 config encoding must be one of the following:", encodings)
+
+        self.access_key = access_key
+        self.secret_access_key = secret_access_key
+        self.bucket = bucket
+        self.encoding = encoding
+
+
+class Store():
+    def __init__(self, backend: str = "redis", config: Union[None, RedisConfig, S3Config] = None):
+        # validate args
+        backends = ["redis", "s3"]
         if backend not in backends:
             raise ValueError("backend must be one of the following:", backends)
 
@@ -45,7 +61,7 @@ class Store():
         if self.backend == "redis":
             if not isinstance(config, RedisConfig):
                 raise ValueError("redis backends require users to bring their own redis, and configure the potassium store to use it with the config argument. For example, to use a local redis, create store with:\n\nfrom potassium.store import Store, RedisConfig\nstore = Store(backend = 'redis', config = RedisConfig(host = 'localhost', port = 6379))")
-            self._redis_store = redis.Redis(
+            self._redis_client = redis.Redis(
                 host=config.host,
                 port=config.port,
                 username=config.username,
@@ -53,13 +69,34 @@ class Store():
                 db=config.db,
             )
 
+        if self.backend == "s3":
+            if not isinstance(config, S3Config):
+                raise ValueError("s3 backends require users to bring their own s3 bucket, and configure the potassium store to use it with the config argument. For example, create store with:\n\nfrom potassium.store import Store, S3Config\nstore = Store(backend = 's3', config = S3Config(access_key, secret_access_key, bucket)")
+            session = boto3.Session(
+                aws_access_key_id=config.access_key,
+                aws_secret_access_key=config.secret_access_key
+            )
+            self._s3_client = session.client('s3')
+            self._s3_bucket = config.bucket
+
     def get(self, key: str):
         if self.backend == "redis":
-            encoded = self._redis_store.get(key)
+            encoded = self._redis_client.get(key)
             if encoded == None:
                 return None
             if self.config.encoding == "json":
                 return json.loads(encoded)
+            if self.config.encoding == "pickle":
+                return pickle.loads(encoded)
+
+        if self.backend == "s3":
+            response = self._s3_client.get_object(
+                Bucket=self._s3_bucket, Key=key)
+            encoded = response['Body'].read()
+            if encoded == None:
+                return None
+            if self.config.encoding == "json":
+                return json.loads(encoded.decode('utf-8'))
             if self.config.encoding == "pickle":
                 return pickle.loads(encoded)
 
@@ -69,4 +106,12 @@ class Store():
                 encoded = json.dumps(value)
             if self.config.encoding == "pickle":
                 encoded = pickle.dumps(value)
-            self._redis_store.set(key, encoded, ex=ttl)
+            self._redis_client.set(key, encoded, ex=ttl)
+
+        if self.backend == "s3":
+            if self.config.encoding == "json":
+                encoded = json.dumps(value)
+            if self.config.encoding == "pickle":
+                encoded = pickle.dumps(value)
+            self._s3_client.put_object(
+                Body=encoded, Bucket=self._s3_bucket, Key=key)

--- a/potassium/store.py
+++ b/potassium/store.py
@@ -35,7 +35,7 @@ class RedisConfig():
 
 class S3Config():
     def __init__(self, access_key, secret_access_key, bucket, encoding: str = "json"):
-        "encoding can be 'json' or 'pickle'. JSON is default.\nPickle has better support for arbitrary python types, but using pickle with a remote redis introduces a large security risk, see https://stackoverflow.com/questions/2259270/pickle-or-json/2259351#2259351"
+        "encoding can be 'json' or 'pickle'. JSON is default.\nPickle has better support for arbitrary python types, but using pickle across the network to s3 introduces a large security risk, see https://stackoverflow.com/questions/2259270/pickle-or-json/2259351#2259351"
         # validate args
         encodings = ["json", "pickle"]
         if encoding not in encodings:

--- a/potassium/store_test.py
+++ b/potassium/store_test.py
@@ -66,8 +66,8 @@ for obj in objs:
 
 
 # s3
-access_key = os.environ["AWS_ACCESS_KEY_ID"]
-secret_access_key = os.environ["AWS_SECRET_ACCESS_KEY"]
+aws_access_key_id = os.environ["AWS_ACCESS_KEY_ID"]
+aws_secret_access_key = os.environ["AWS_SECRET_ACCESS_KEY"]
 bucket = "potassium-test"
 
 
@@ -75,8 +75,8 @@ bucket = "potassium-test"
 store = Store(
     backend="s3",
     config=S3Config(
-        access_key=access_key,
-        secret_access_key=secret_access_key,
+        aws_access_key_id=aws_access_key_id,
+        aws_secret_access_key=aws_secret_access_key,
         bucket=bucket,
     )
 )
@@ -119,8 +119,8 @@ objs = [
 store = Store(
     backend="s3",
     config=S3Config(
-        access_key=access_key,
-        secret_access_key=secret_access_key,
+        aws_access_key_id=aws_access_key_id,
+        aws_secret_access_key=aws_secret_access_key,
         bucket=bucket,
         encoding="pickle"
     )

--- a/potassium/store_test.py
+++ b/potassium/store_test.py
@@ -1,4 +1,5 @@
-from store import Store, RedisConfig
+import os
+from store import Store, RedisConfig, S3Config
 
 # Redis store can save json serializeable objects
 store = Store(
@@ -49,6 +50,78 @@ store = Store(
     config=RedisConfig(
         host="localhost",
         port=6379,
+        encoding="pickle"
+    )
+)
+
+print("Testing pickle redis")
+for obj in objs:
+    store.set("key", obj)
+    out = store.get("key")
+    if obj != obj:
+        print("failed case", obj)
+
+
+# ----
+
+
+# s3
+access_key = os.environ["AWS_ACCESS_KEY_ID"]
+secret_access_key = os.environ["AWS_SECRET_ACCESS_KEY"]
+bucket = "potassium-test"
+
+
+# s3 store can save json serializeable objects
+store = Store(
+    backend="s3",
+    config=S3Config(
+        access_key=access_key,
+        secret_access_key=secret_access_key,
+        bucket=bucket,
+    )
+)
+
+objs = [
+    "1",
+    True,
+    ["some", "list"],
+    {"some": {"nested": "dict"}}
+]
+
+print("Testing json redis")
+for obj in objs:
+    store.set("key", obj)
+    out = store.get("key")
+    if out != obj:
+        print("failed case", obj)
+
+# ----
+
+# pickle s3 can save complex objects
+
+
+class Complex():
+    def __init__(self, a) -> None:
+        self.a = a
+
+    def __eq__(self, other):  # necessary for the equal assert later
+        return self.a == other.a
+
+
+objs = [
+    "1",
+    True,
+    ["some", "list"],
+    {"some": {"nested": "dict"}},
+    Complex(a=1)
+]
+
+store = Store(
+    backend="s3",
+    config=S3Config(
+        access_key=access_key,
+        secret_access_key=secret_access_key,
+        bucket=bucket,
         encoding="pickle"
     )
 )

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ setup(
         "Flask",
         "requests",
         "termcolor",
-        "redis"
+        "redis",
+        "boto3"
     ],
     classifiers=[
         # Chose either "3 - Alpha", "4 - Beta" or "5 - Production/Stable" as the current state of your package


### PR DESCRIPTION
# What is this?
Adds s3 as a backend to potassium's key-value store.

It has similar behavior as redis: default json encoding for simple objects, optional (but warned to be dangerous) pickle encoding for arbitrary objects

# Why?
Because we removed the localstore option, it felt valuable to have at least another backend

# How did you test it works without regressions?
Wrote unit tests and they pass

