### PR TITLE
adds the set_context method to app

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,4 +1,4 @@
-from potassium import Potassium, Request, Response, send_webhook
+from potassium import Potassium, Request, Response, set_context
 from transformers import pipeline
 import torch
 import time
@@ -27,6 +27,8 @@ def handler(context: dict, request: Request) -> Response:
     prompt = request.json.get("prompt")
     model = context.get("model")
     outputs = model(prompt)
+
+    app.set_context()
 
     return Response(
         json={"outputs": outputs},

--- a/example.py
+++ b/example.py
@@ -1,11 +1,8 @@
-from potassium import Potassium, Request, Response, set_context
+from potassium import Potassium, Request, Response
 from transformers import pipeline
 import torch
-import time
 
 app = Potassium("my_app")
-
-# @app.init runs at startup, and initializes the app's context
 
 
 @app.init
@@ -27,8 +24,6 @@ def handler(context: dict, request: Request) -> Response:
     prompt = request.json.get("prompt")
     model = context.get("model")
     outputs = model(prompt)
-
-    app.set_context()
 
     return Response(
         json={"outputs": outputs},


### PR DESCRIPTION
# What is this?
a set_context method, which overwrites context from the handler

# Why?
for users who want to persist objects between handlers, without using hacky global vars

# How did you test it works without regressions?
Ran it across multiple calls

# If this is a new feature what may a critical error (P0) look like? 
Not a P0, but a P2ish error may me users getting confused and erasing their own contexts, or forgetting that a modified context is only on that specific replica
