### PR TITLE
added print in case of exception in handler

### DIFF
--- a/potassium/potassium.py
+++ b/potassium/potassium.py
@@ -118,6 +118,7 @@ class Potassium():
                     return res
                 except:
                     tb_str = traceback.format_exc()
+                    print(colored(tb_str, "red"))
                     res = make_response(tb_str)
                     res.status_code = 500
                     res.headers['X-Endpoint-Type'] = endpoint.type

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ long_description = (this_directory / "README.md").read_text()
 setup(
     name='potassium',
     packages=['potassium'],
-    version='0.1.0',
+    version='0.1.1',
     license='Apache License 2.0',
     # Give a short description about your library
     description='The potassium package is a flask-like HTTP server for serving large AI models',


### PR DESCRIPTION
# What is this?
We print in the case of an exception in the handler

# Why?
Debug was weird; the exception tracebacks were returning in the client rather than the server lol

# How did you test it works without regressions?
e2e tests
- healthy call to handler
- call to broken handler (it prints the traceback in red)

# If this is a new feature what may a critical error (P0) look like? 
N/A
