### PR TITLE
raise Exception on endpoint collision + handle empty init

### DIFF
--- a/example.py
+++ b/example.py
@@ -17,7 +17,6 @@ def init():
 
     return context
 
-
 @app.handler(route = "/")
 def handler(context: dict, request: Request) -> Response:
     prompt = request.json.get("prompt")
@@ -28,7 +27,6 @@ def handler(context: dict, request: Request) -> Response:
         json={"outputs": outputs},
         status=200
     )
-
 
 if __name__ == "__main__":
     app.serve()

--- a/example.py
+++ b/example.py
@@ -18,7 +18,7 @@ def init():
     return context
 
 
-@app.handler()
+@app.handler(route = "/")
 def handler(context: dict, request: Request) -> Response:
     prompt = request.json.get("prompt")
     model = context.get("model")

--- a/potassium/potassium.py
+++ b/potassium/potassium.py
@@ -31,6 +31,7 @@ class Potassium():
     def __init__(self, name):
         self.name = name
 
+        # default init function, if the user doesn't specify one
         def empty_init():
             return {}
 
@@ -53,6 +54,7 @@ class Potassium():
         """
 
         def wrapper():
+            print(colored("Running init()", 'yellow'))
             self._context = func()
             if not isinstance(self._context, dict):
                 raise Exception("Potassium init() must return a dictionary")
@@ -204,7 +206,6 @@ class Potassium():
     # serve runs the http server
     def serve(self, host="0.0.0.0", port=8000):
         print(colored("------\nStarting Potassium Server 🍌", 'yellow'))
-        print(colored("Running init()", 'yellow'))
         self._init_func()
         flask_app = self._create_flask_app()
         server = make_server(host, port, flask_app)

--- a/potassium/potassium.py
+++ b/potassium/potassium.py
@@ -75,7 +75,11 @@ class Potassium():
                         "Potassium Response object json must be a dict")
 
                 return out
+            
 
+            if route in self._endpoints:
+                raise Exception("Route already in use")
+            
             self._endpoints[route] = Endpoint(type="handler", func=wrapper)
             return wrapper
         return actual_decorator
@@ -88,6 +92,9 @@ class Potassium():
             def wrapper(request):
                 # send in app's stateful context if GPU, and the request
                 return func(self._context, request)
+            
+            if route in self._endpoints:
+                raise Exception("Route already in use")
 
             self._endpoints[route] = Endpoint(
                 type="background", func=wrapper)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ long_description = (this_directory / "README.md").read_text()
 setup(
     name='potassium',
     packages=['potassium'],
-    version='0.1.1',
+    version='0.1.2',
     license='Apache License 2.0',
     # Give a short description about your library
     description='The potassium package is a flask-like HTTP server for serving large AI models',


### PR DESCRIPTION
# What is this?
We raise an Exception when routes are repeated
+ standardization for endpoint routs to be "/"+route
+ handling for route=None

plus a sidequest
+ handling the case where context returns a non-dict
+ handling the case where init isn't ran

# Why?
Both endpoint collision and misuse of init were leading to user confusion

# How did you test it works without regressions?
Local tests with multiple endpoints
- mixed (/route, route) cases to test the standardization
- mixed handler/background cases to test if collisions are still detected
- route=None case
- no init case
- init returning non-dict case

# If this is a new feature what may a critical error look like? 
not new feature, but technically a breaking change since we raise exceptions in these cases rather than silently fail.