### PR TITLE
Feature/track gpu status

### DIFF
--- a/potassium/potassium.py
+++ b/potassium/potassium.py
@@ -169,10 +169,12 @@ class Potassium():
             def task(endpoint, lock, req):
                 try:
                     endpoint.func(req)
-                    lock.release()
                 except Exception as e:
                     # do any cleanup before re-raising user error
                     raise e
+                finally:
+                    # release lock
+                    lock.release()
 
             thread = Thread(target=task, args=(endpoint, self._gpu_lock, req))
             thread.start()

--- a/potassium/potassium.py
+++ b/potassium/potassium.py
@@ -45,6 +45,7 @@ class Potassium():
         self._endpoints = {}  
         self._context = {}
         self._gpu_lock = Lock()
+        self._sequence_number = 0
         self._flask_app = self._create_flask_app()
 
     #
@@ -135,6 +136,7 @@ class Potassium():
         # potassium rejects if lock already in use
         try:
             self._gpu_lock.acquire(blocking=False)
+            self._sequence_number += 1
         except:
             res = make_response()
             res.status_code = 423
@@ -217,7 +219,8 @@ class Potassium():
         @flask_app.route('/__status__', methods=["GET"])
         def status():
             res = make_response({
-                "gpu_available": not self._gpu_lock.locked()
+                "gpu_available": not self._gpu_lock.locked(),
+                "sequence_number": self._sequence_number
             })
 
             res.status_code = 200

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,3 +1,6 @@
+import queue
+import threading
+import time
 import pytest
 import potassium
 
@@ -47,17 +50,45 @@ def test_handler():
 def test_background():
     app = potassium.Potassium("my_app")
 
+    order_of_execution_queue = queue.Queue()
+    resolve_background_condition = threading.Condition()
+
     @app.init
     def init():
         return {}
 
     @app.background("/background")
     def background(context: dict, request: potassium.Request):
-        pass
+        order_of_execution_queue.put("background_started")
+        with resolve_background_condition:
+            resolve_background_condition.wait()
+
     client = app.test_client()
 
+    # send post in separate thread
     res = client.post("/background", json={})
     assert res.status_code == 200
+
+    def wait_for_lock():
+        order_of_execution_queue.put("wait_for_lock")
+        app.block_until_gpu_lock_released()
+        order_of_execution_queue.put("lock_released")
+
+    thread = threading.Thread(target=wait_for_lock)
+    thread.start()
+
+    # notify background thread to continue
+    order_of_execution_queue.put("notify_background")
+    with resolve_background_condition:
+        resolve_background_condition.notify()
+
+    thread.join()
+
+    # assert order of execution
+    assert order_of_execution_queue.get() == "background_started"
+    assert order_of_execution_queue.get() == "wait_for_lock"
+    assert order_of_execution_queue.get() == "notify_background"
+    assert order_of_execution_queue.get() == "lock_released"
 
 # parameterized test for path collisions
 @pytest.mark.parametrize("paths", [
@@ -86,4 +117,49 @@ def test_path_collision(paths):
                 json={},
                 status=200
             )
+
+def test_status():
+    app = potassium.Potassium("my_app")
+
+    resolve_background_condition = threading.Condition()
+
+    @app.init
+    def init():
+        return {}
+
+    @app.background("/background")
+    def background(context: dict, request: potassium.Request):
+        with resolve_background_condition:
+            resolve_background_condition.wait()
+
+    client = app.test_client()
+
+    # send get for status
+    res = client.get("/__status__", json={})
+
+    assert res.status_code == 200
+    assert res.json == {"gpu_available": True}
+
+    # send background post in separate thread
+    res = client.post("/background", json={})
+    assert res.status_code == 200
+
+    # check status
+    res = client.get("/__status__", json={})
+
+    assert res.status_code == 200
+    assert res.json == {"gpu_available": False}
+
+    # notify background thread to continue
+    with resolve_background_condition:
+        resolve_background_condition.notify()
+
+    # wait for the lock to be released
+    app.block_until_gpu_lock_released()
+
+    # check status
+    res = client.get("/__status__", json={})
+
+    assert res.status_code == 200
+    assert res.json == {"gpu_available": True}
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -138,7 +138,10 @@ def test_status():
     res = client.get("/__status__", json={})
 
     assert res.status_code == 200
-    assert res.json == {"gpu_available": True}
+    assert res.json == {
+        "gpu_available": True,
+        "sequence_number": 0,
+    }
 
     # send background post in separate thread
     res = client.post("/background", json={})
@@ -148,7 +151,10 @@ def test_status():
     res = client.get("/__status__", json={})
 
     assert res.status_code == 200
-    assert res.json == {"gpu_available": False}
+    assert res.json == {
+        "gpu_available": False,
+        "sequence_number": 1,
+    }
 
     # notify background thread to continue
     with resolve_background_condition:
@@ -161,5 +167,8 @@ def test_status():
     res = client.get("/__status__", json={})
 
     assert res.status_code == 200
-    assert res.json == {"gpu_available": True}
+    assert res.json == {
+        "gpu_available": True,
+        "sequence_number": 1,
+    }
 


### PR DESCRIPTION
# What is this?
Adds two fields to `/__status__` endpoint: `gpu_available: bool` and `sequence_number: int`

gpu_available is true if the gpu lock is not locked. sequence_number increments by one every time a task acquires the GPU.

This PR also refactors how we're dealing with locks in potassium eliminating a few race conditions.

# Why?

Using both of these, a load balancer can effectively determine the current state of a potassium deployment. 

# How did you test it works without  regressions?

tests are passing + manual toy app is working as well (more thorough testing should be done with cover in prod before merging staging into main to ensure integration is safe)

# If this is a new feature what may a critical error look like? 

### Things to consider to not repeat mistakes we've learned from many times
- [ ] If critical errors fire do we ping team in some obvious way (e.g., slack)? 
- [ ] Are there debug logs + a way to see these logs if we need to debug?
- [ ] Is this documented enough a dev could work on this code without getting stuck or having to ping you?
