### PR TITLE
add idle time status

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from distutils.core import setup
-import setuptools
 from pathlib import Path
 
 this_directory = Path(__file__).parent

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -95,10 +95,10 @@ def test_status():
     res = client.get("/__status__", json={})
 
     assert res.status_code == 200
-    assert res.json == {
-        "gpu_available": True,
-        "sequence_number": 0,
-    }
+    assert res.json is not None
+    assert res.json["gpu_available"] == True
+    assert res.json["sequence_number"] == 0
+    assert res.json["idle_time"] > 0
 
     # send background post in separate thread
     res = client.post("/background", json={})
@@ -108,10 +108,10 @@ def test_status():
     res = client.get("/__status__", json={})
 
     assert res.status_code == 200
-    assert res.json == {
-        "gpu_available": False,
-        "sequence_number": 1,
-    }
+    assert res.json is not None
+    assert res.json["gpu_available"] == False
+    assert res.json["sequence_number"] == 1
+    assert res.json["idle_time"] == 0
 
     # notify background thread to continue
     with resolve_background_condition:
@@ -124,10 +124,10 @@ def test_status():
     res = client.get("/__status__", json={})
 
     assert res.status_code == 200
-    assert res.json == {
-        "gpu_available": True,
-        "sequence_number": 1,
-    }
+    assert res.json is not None
+    assert res.json["gpu_available"] == True
+    assert res.json["sequence_number"] == 1
+    assert res.json["idle_time"] > 0
 
 def test_wait_for_background_task():
     app = potassium.Potassium("my_app")


### PR DESCRIPTION
# What is this?
Adds idle time reporting to potassium status endpoint.

# Why?
IdleTime is a useful metric for a load balancer to track to know when to scale down replicas.

# How did you test it works without  regressions?
unit tests passing + manual testing

# If this is a new feature what may a critical error look like? 

### Things to consider to not repeat mistakes we've learned from many times
- [ ] If critical errors fire do we ping team in some obvious way (e.g., slack)? 
- [ ] Are there debug logs + a way to see these logs if we need to debug?
- [ ] Is this documented enough a dev could work on this code without getting stuck or having to ping you?
