### PR TITLE
Erikk/ban 375 inference time to potassium

### DIFF
--- a/potassium/potassium.py
+++ b/potassium/potassium.py
@@ -226,8 +226,12 @@ class Potassium():
         @flask_app.route('/__status__', methods=["GET"])
         def status():
             idle_time = 0
-            inference_time = int((time.time() - self._inference_start_time)*1000)
             gpu_available = not self._gpu_lock.locked()
+
+            if self._inference_start_time != 0:
+                inference_time = int((time.time() - self._inference_start_time)*1000)
+            else:
+                inference_time = 0
 
             if gpu_available:
                 idle_time = int((time.time() - self._idle_start_time)*1000)

--- a/potassium/potassium.py
+++ b/potassium/potassium.py
@@ -167,6 +167,7 @@ class Potassium():
                 res.status_code = 500
                 res.headers['X-Endpoint-Type'] = endpoint.type
             self._idle_start_time = time.time()
+            self._inference_start_time = 0
             self._gpu_lock.release()
         elif endpoint.type == "background":
             req = Request(
@@ -185,6 +186,7 @@ class Potassium():
                         self._background_task_cv.notify_all()
 
                         self._idle_start_time = time.time()
+                        self._inference_start_time = 0
                         lock.release()
 
             thread = Thread(target=task, args=(endpoint, self._gpu_lock, req))
@@ -228,11 +230,11 @@ class Potassium():
             idle_time = 0
             gpu_available = not self._gpu_lock.locked()
 
-            if self._inference_start_time != 0:
+            if self._inference_start_time != 0:            
                 inference_time = int((time.time() - self._inference_start_time)*1000)
             else:
                 inference_time = 0
-
+            
             if gpu_available:
                 idle_time = int((time.time() - self._idle_start_time)*1000)
 

--- a/potassium/potassium.py
+++ b/potassium/potassium.py
@@ -249,7 +249,7 @@ class Potassium():
     def serve(self, host="0.0.0.0", port=8000):
         print(colored("------\nStarting Potassium Server 🍌", 'yellow'))
         self._init_func()
-        server = make_server(host, port, self._flask_app)
+        server = make_server(host, port, self._flask_app, threaded=True)
         print(colored(f"Serving at http://{host}:{port}\n------", 'green'))
         self._idle_start_time = time.time()
         self._inference_start_time = time.time()

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from distutils.core import setup
-import setuptools
 from pathlib import Path
 
 this_directory = Path(__file__).parent

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -99,7 +99,7 @@ def test_status():
     assert res.json["gpu_available"] == True
     assert res.json["sequence_number"] == 0
     assert res.json["idle_time"] > 0
-    assert res.json["inference_time"] > 0
+    assert res.json["inference_time"] == 0
 
     # send background post in separate thread
     res = client.post("/background", json={})

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -105,6 +105,9 @@ def test_status():
     res = client.post("/background", json={})
     assert res.status_code == 200
 
+    # add a small sleep for inference time to be above 0
+    time.sleep(0.1)
+
     # check status
     res = client.get("/__status__", json={})
 
@@ -113,7 +116,7 @@ def test_status():
     assert res.json["gpu_available"] == False
     assert res.json["sequence_number"] == 1
     assert res.json["idle_time"] == 0
-    assert res.json["inference_time"] == 0
+    assert res.json["inference_time"] > 0
 
     # notify background thread to continue
     with resolve_background_condition:

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -95,10 +95,10 @@ def test_status():
     res = client.get("/__status__", json={})
 
     assert res.status_code == 200
-    assert res.json == {
-        "gpu_available": True,
-        "sequence_number": 0,
-    }
+    assert res.json is not None
+    assert res.json["gpu_available"] == True
+    assert res.json["sequence_number"] == 0
+    assert res.json["idle_time"] > 0
 
     # send background post in separate thread
     res = client.post("/background", json={})
@@ -108,10 +108,10 @@ def test_status():
     res = client.get("/__status__", json={})
 
     assert res.status_code == 200
-    assert res.json == {
-        "gpu_available": False,
-        "sequence_number": 1,
-    }
+    assert res.json is not None
+    assert res.json["gpu_available"] == False
+    assert res.json["sequence_number"] == 1
+    assert res.json["idle_time"] == 0
 
     # notify background thread to continue
     with resolve_background_condition:
@@ -124,10 +124,10 @@ def test_status():
     res = client.get("/__status__", json={})
 
     assert res.status_code == 200
-    assert res.json == {
-        "gpu_available": True,
-        "sequence_number": 1,
-    }
+    assert res.json is not None
+    assert res.json["gpu_available"] == True
+    assert res.json["sequence_number"] == 1
+    assert res.json["idle_time"] > 0
 
 def test_wait_for_background_task():
     app = potassium.Potassium("my_app")

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -133,7 +133,7 @@ def test_status():
     assert res.json["gpu_available"] == True
     assert res.json["sequence_number"] == 1
     assert res.json["idle_time"] > 0
-    assert res.json["inference_time"] > 0
+    assert res.json["inference_time"] == 0
 
 def test_wait_for_background_task():
     app = potassium.Potassium("my_app")

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -99,6 +99,7 @@ def test_status():
     assert res.json["gpu_available"] == True
     assert res.json["sequence_number"] == 0
     assert res.json["idle_time"] > 0
+    assert res.json["inference_time"] > 0
 
     # send background post in separate thread
     res = client.post("/background", json={})
@@ -112,6 +113,7 @@ def test_status():
     assert res.json["gpu_available"] == False
     assert res.json["sequence_number"] == 1
     assert res.json["idle_time"] == 0
+    assert res.json["inference_time"] == 0
 
     # notify background thread to continue
     with resolve_background_condition:
@@ -128,6 +130,7 @@ def test_status():
     assert res.json["gpu_available"] == True
     assert res.json["sequence_number"] == 1
     assert res.json["idle_time"] > 0
+    assert res.json["inference_time"] > 0
 
 def test_wait_for_background_task():
     app = potassium.Potassium("my_app")


### PR DESCRIPTION
# What is this?
- add inference time as a return variable to potassium apps

# Why?
Part of https://linear.app/banana-dev/issue/BAN-358/add-timeout-on-replicas-that-stay-unavailable-above-threshold

# How did you test it works without  regressions?

# If this is a new feature what may a critical error look like? 

### Things to consider to not repeat mistakes we've learned from many times
- [ ] If critical errors fire do we ping team in some obvious way (e.g., slack)? 
- [x] Are there debug logs + a way to see these logs if we need to debug?
- [x] Is this documented enough a dev could work on this code without getting stuck or having to ping you?
