### PR TITLE
Add request ID into request, and include headers

### DIFF
--- a/potassium/potassium.py
+++ b/potassium/potassium.py
@@ -17,15 +17,17 @@ class Endpoint():
 
 
 class Request():
-    def __init__(self, json: dict):
+    def __init__(self, id: str, headers: dict, json: dict):
+        self.id = id
+        self.headers = headers
         self.json = json
-
 
 ResponseBody = Union[bytes, Generator[bytes, None, None]]
 
 class Response():
     def __init__(self, status: int = 200, json: Optional[dict] = None, headers: Optional[dict] = None, body: Optional[ResponseBody] = None):
         assert json == None or body == None, "Potassium Response object cannot have both json and body set"
+
 
         self.headers = headers if headers != None else {}
 
@@ -181,7 +183,9 @@ class Potassium():
 
         try:
             req = Request(
-                json=flask_request.get_json()
+                headers=dict(flask_request.headers),
+                json=flask_request.get_json(),
+                id=flask_request.headers.get("X-Banana-Request-Id", "")
             )
         except:
             res = make_response()

--- a/potassium/potassium.py
+++ b/potassium/potassium.py
@@ -3,6 +3,7 @@ from types import GeneratorType
 from typing import Generator, Optional, Union
 from flask import Flask, request, make_response, abort, Response as FlaskResponse
 from werkzeug.serving import make_server
+from werkzeug.datastructures.headers import EnvironHeaders
 from threading import Thread, Lock, Condition
 import functools
 import traceback
@@ -15,9 +16,8 @@ class Endpoint():
         self.type = type
         self.func = func
 
-
 class Request():
-    def __init__(self, id: str, headers: dict, json: dict):
+    def __init__(self, id: str, headers: EnvironHeaders, json: dict):
         self.id = id
         self.headers = headers
         self.json = json
@@ -183,7 +183,7 @@ class Potassium():
 
         try:
             req = Request(
-                headers=dict(flask_request.headers),
+                headers=flask_request.headers,
                 json=flask_request.get_json(),
                 id=flask_request.headers.get("X-Banana-Request-Id", "")
             )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = (this_directory / "README.md").read_text()
 setup(
     name='potassium',
     packages=['potassium'],
-    version='0.4.0',
+    version='0.4.1',
     license='Apache License 2.0',
     # Give a short description about your library
     description='The potassium package is a flask-like HTTP server for serving large AI models',


### PR DESCRIPTION
# What is this?
potassium Requests now have these fields:
**.id** - the request ID from Banana, sent as "X-Banana-Request-Id" in headers
**.headers** - the headers from the original request

# Why?
.id is needed so users can include the request.id in their logs for filtering in Banana
.headers is needed because we're an important http framework 💪 

# How did you test it works without regressions?
Tests pass, added new tests.

# If this is a new feature what may a critical error look like? 
Headers, depending on the http client sending them, may have their cases changed, so the assumption is that users **test their code** before using this

### Things to consider to not repeat mistakes we've learned from many times
- [ ] If critical errors fire do we ping team in some obvious way (e.g., slack)? 
- [x] Are there debug logs + a way to see these logs if we need to debug?
- [x] Is this documented enough a dev could work on this code without getting stuck or having to ping you?
